### PR TITLE
Implement reading ARM9/ARM7 from built NDS file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,17 +31,16 @@
 *.out
 *.app
 
-# devKitArm/LibNDS/3DS compiled stuff
+# devkitARM/libnds/3DS compiled stuff
 *.bin
 *.tmd
 *.cia
+*.nds
 *.app
 *.arm7
 *.arm9
 *.elf
-arm9/data/
-arm7/build
-arm9/build/
+build
 data
 
 # Stuff used to build custom banner/misc other things that shouldn't be in repo.


### PR DESCRIPTION
This change will flash the ARM binaries from `/dsx_firmware.nds`.

Some sanity checks are added to make sure the ARM binaries do not exceed the limit we have placed. Previously, there was no check at all.

Since this change uses the full NDS file, we are also able to sanity check the entrypoint/load addresses of the binaries in question; as of DS-Xtreme firmware 1.1.3, this is ARM9=0x02000000 and ARM7=0x03800000.

Banner writing is untouched.